### PR TITLE
Port config, Vagrant provision and nginx site bugfix

### DIFF
--- a/HelloWorld/HelloWorld/Program.cs
+++ b/HelloWorld/HelloWorld/Program.cs
@@ -20,6 +20,7 @@ namespace HelloWorld
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .UseUrls("http://localhost:5000")
                 .Build();
     }
 }

--- a/Provision/README.md
+++ b/Provision/README.md
@@ -1,0 +1,5 @@
+# Vagrant provision files & config
+
+## In this folder:
+
+1. Nginx proxy settings for the default site

--- a/Provision/nginx/default-site
+++ b/Provision/nginx/default-site
@@ -1,0 +1,118 @@
+# You may add here your
+# server {
+#	...
+# }
+# statements for each of your virtual hosts to this file
+
+##
+# You should look at the following URL's in order to grasp a solid understanding
+# of Nginx configuration files in order to fully unleash the power of Nginx.
+# http://wiki.nginx.org/Pitfalls
+# http://wiki.nginx.org/QuickStart
+# http://wiki.nginx.org/Configuration
+#
+# Generally, you will want to move this file somewhere, and start with a clean
+# file but keep this around for reference. Or just disable in sites-enabled.
+#
+# Please see /usr/share/doc/nginx-doc/examples/ for more detailed examples.
+##
+
+server {
+	listen 80 default_server;
+	listen [::]:80 default_server ipv6only=on;
+
+	root /usr/share/nginx/html;
+	index index.html index.htm;
+
+	# Make site accessible from http://localhost/
+	server_name localhost;
+
+	location / {
+		# First attempt to serve request as file, then
+		# as directory, then fall back to displaying a 404.
+		try_files $uri $uri/ =404;
+		# Uncomment to enable naxsi on this location
+		# include /etc/nginx/naxsi.rules
+	        proxy_pass http://localhost:5000;
+	        proxy_http_version 1.1;
+        	proxy_set_header Upgrade $http_upgrade;
+	        proxy_set_header Connection keep-alive;
+        	proxy_set_header Host $host;
+	        proxy_cache_bypass $http_upgrade;
+	}
+
+	# Only for nginx-naxsi used with nginx-naxsi-ui : process denied requests
+	#location /RequestDenied {
+	#	proxy_pass http://127.0.0.1:8080;    
+	#}
+
+	#error_page 404 /404.html;
+
+	# redirect server error pages to the static page /50x.html
+	#
+	#error_page 500 502 503 504 /50x.html;
+	#location = /50x.html {
+	#	root /usr/share/nginx/html;
+	#}
+
+	# pass the PHP scripts to FastCGI server listening on 127.0.0.1:9000
+	#
+	#location ~ \.php$ {
+	#	fastcgi_split_path_info ^(.+\.php)(/.+)$;
+	#	# NOTE: You should have "cgi.fix_pathinfo = 0;" in php.ini
+	#
+	#	# With php5-cgi alone:
+	#	fastcgi_pass 127.0.0.1:9000;
+	#	# With php5-fpm:
+	#	fastcgi_pass unix:/var/run/php5-fpm.sock;
+	#	fastcgi_index index.php;
+	#	include fastcgi_params;
+	#}
+
+	# deny access to .htaccess files, if Apache's document root
+	# concurs with nginx's one
+	#
+	#location ~ /\.ht {
+	#	deny all;
+	#}
+}
+
+
+# another virtual host using mix of IP-, name-, and port-based configuration
+#
+#server {
+#	listen 8000;
+#	listen somename:8080;
+#	server_name somename alias another.alias;
+#	root html;
+#	index index.html index.htm;
+#
+#	location / {
+#		try_files $uri $uri/ =404;
+#	}
+#}
+
+
+# HTTPS server
+#
+#server {
+#	listen 443;
+#	server_name localhost;
+#
+#	root html;
+#	index index.html index.htm;
+#
+#	ssl on;
+#	ssl_certificate cert.pem;
+#	ssl_certificate_key cert.key;
+#
+#	ssl_session_timeout 5m;
+#
+#	ssl_protocols SSLv3 TLSv1 TLSv1.1 TLSv1.2;
+#	ssl_ciphers "HIGH:!aNULL:!MD5 or HIGH:!aNULL:!MD5:!3DES";
+#	ssl_prefer_server_ciphers on;
+#
+#	location / {
+#		try_files $uri $uri/ =404;
+#	}
+#}

--- a/Provision/nginx/default-site
+++ b/Provision/nginx/default-site
@@ -30,7 +30,8 @@ server {
 	location / {
 		# First attempt to serve request as file, then
 		# as directory, then fall back to displaying a 404.
-		try_files $uri $uri/ =404;
+		# try_files $uri $uri/ =404;
+
 		# Uncomment to enable naxsi on this location
 		# include /etc/nginx/naxsi.rules
 	        proxy_pass http://localhost:5000;

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -32,6 +32,12 @@ Vagrant.configure(2) do |config|
 
         sudo apt-get update
         sudo apt-get install dotnet-sdk-2.0.3 -y
+
+        apt-get update
+        apt-get install -y nginx
+        sudo apt-get clean
+
+        service nginx restart
     SCRIPT
   
     config.vm.provision "shell", inline: $script

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -8,6 +8,7 @@ Vagrant.configure(2) do |config|
     config.vm.network "forwarded_port", guest: 80, host: 8080, auto_correct: true
 
     # Synced folder
+    config.vm.synced_folder "./Provision", "/vagrant"
     config.vm.synced_folder "#{ENV['HOME']}/Dev/",
         "/data/sites",
         :owner => 'vagrant',
@@ -31,11 +32,13 @@ Vagrant.configure(2) do |config|
         sudo sh -c 'echo "deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main" > /etc/apt/sources.list.d/dotnetdev.list'
 
         sudo apt-get update
-        sudo apt-get install dotnet-sdk-2.0.3 -y
+        sudo apt-get install -y dotnet-sdk-2.0.3
 
         apt-get update
         apt-get install -y nginx
         sudo apt-get clean
+
+        cat /vagrant/nginx/default-site > /etc/nginx/sites-available/default
 
         service nginx restart
     SCRIPT

--- a/WebApi/UserWebApi/Program.cs
+++ b/WebApi/UserWebApi/Program.cs
@@ -20,6 +20,7 @@ namespace UserWebApi
         public static IWebHost BuildWebHost(string[] args) =>
             WebHost.CreateDefaultBuilder(args)
                 .UseStartup<Startup>()
+                .UseUrls("http://localhost:5000")
                 .Build();
     }
 }


### PR DESCRIPTION
There was a bug causing nginx to not resolve the proxy sometimes, it was because the config was validating that the requested file existed on the file system, and, of course, they don't, as routes are handled by Controllers.

This fix removes that validation and also adds a Provisions folder to handle default settings that might be needed in the future when provisioning the Vagrant box. So far only the nginx default site proxy config is in there, but in the future others could be easily integrated